### PR TITLE
Don't shade GP

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
             <groupId>com.github.TechFortress</groupId>
             <artifactId>GriefPrevention</artifactId>
             <version>16.13.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.Angeschossen</groupId>


### PR DESCRIPTION
Current build posted on Spigot includes the entirety of GP shaded in, resulting in complete GP incompatibility. Didn't do more than a cursory inspection of the code using GP, but it all looked okay.

TechFortress/GriefPrevention#798